### PR TITLE
Make MySQL Installation Optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,17 @@ Just include `phabricator` in your node's `run_list`:
 }
 ```
 
+###### MySQL Installation
+
+If node['phabricator]['mysql_host'] is set to `localhost` then the cookbook
+will also install and configure the mysql server appropriately.
+
+Otherwise setting to a remote host (e.g. Amazon RDS) will configure phabricator
+to connect to that.
+
 Bugs
 ----
-It's not yet possible to use an external MySQL server, but feel free to submit patches.
+
 
 Contributing
 ------------

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -32,46 +32,21 @@ nginx_enabled_conf = "/etc/nginx/sites-enabled/#{node['phabricator']['domain']}.
 # Make sure the package list is up to date
 include_recipe 'apt'
 
-# Make sure MySQL has a default root password
-if not node.run_state.has_key?('mysql_root_password') then
-    Chef::Log.warn("****** Your MySQL password is set to an insecure default value, please modify it using `node.run_state['mysql_root_password']`! ******")
-    node.run_state['mysql_root_password'] = 'pleaserootmydatabase'
-end
-
-# Set up a MySQL server
-mysql_service 'default' do
-    initial_root_password node.run_state['mysql_root_password']
-    version node['mysql']['version']
-    action [:create, :start]
-end
-
-# Define MySQL connection credentials
-mysql_connection = {
-    :host => '127.0.0.1',
-    :port => 3306,
-    :user => 'root',
-    :password => node.run_state['mysql_root_password']
-}
-
 # Include needed recipes
 include_recipe "nginx"
 include_recipe "php"
 include_recipe "php-fpm"
-include_recipe "database::mysql"
+
+# Only install MySQL if it is local. ::1 is ipv6 loopback.
+if ['localhost', '127.0.0.1', '::1'].include?(node['phabricator']['mysql_host'])
+    include_recipe 'phabricator::mysql_server'
+end
 
 # Install required packages for Phabricator
 node['phabricator']['packages'].each do |p|
     package p do
         action :upgrade
     end
-end
-
-# Phabricator needs special MySQL configuration.
-mysql_config 'phabricator' do
-    source 'phabricator.cnf.erb'
-    instance 'default'
-    action :create
-    notifies :restart, 'mysql_service[default]'
 end
 
 group node['phabricator']['group'] do
@@ -156,14 +131,6 @@ link nginx_enabled_conf do
     to nginx_available_conf
     action :create
     notifies :reload, "service[nginx]"
-end
-
-mysql_database_user node['phabricator']['mysql_user'] do
-    connection mysql_connection
-    password node['phabricator']['mysql_password']
-    database_name 'phabricator_%'
-    privileges [:all]
-    action [:create, :grant]
 end
 
 # Set the MySQL credentials first of all

--- a/recipes/mysql_server.rb
+++ b/recipes/mysql_server.rb
@@ -1,0 +1,53 @@
+#
+# Cookbook Name:: phabricator
+# Recipe:: mysql_server
+#
+# Copyright 2014, MET Norway
+#
+# Authors: Kim Tore Jensen <kimtj@met.no>
+#          Andrew Mulholland <andrew@bash.sh>
+#
+# Installs and configures MySQL for Phabricator
+
+# Make sure the package list is up to date
+include_recipe 'apt'
+
+# Make sure MySQL has a default root password
+if not node.run_state.has_key?('mysql_root_password') then
+    Chef::Log.warn("****** Your MySQL password is set to an insecure default value, please modify it using `node.run_state['mysql_root_password']`! ******")
+    node.run_state['mysql_root_password'] = 'pleaserootmydatabase'
+end
+
+# Set up a MySQL server
+mysql_service 'default' do
+    initial_root_password node.run_state['mysql_root_password']
+    version node['mysql']['version']
+    action [:create, :start]
+end
+
+# Define MySQL connection credentials
+mysql_connection = {
+    :host => '127.0.0.1',
+    :port => 3306,
+    :user => 'root',
+    :password => node.run_state['mysql_root_password']
+}
+
+# Include needed recipes
+include_recipe "database::mysql"
+
+# Phabricator needs special MySQL configuration.
+mysql_config 'phabricator' do
+    source 'phabricator.cnf.erb'
+    instance 'default'
+    action :create
+    notifies :restart, 'mysql_service[default]'
+end
+
+mysql_database_user node['phabricator']['mysql_user'] do
+    connection mysql_connection
+    password node['phabricator']['mysql_password']
+    database_name 'phabricator_%'
+    privileges [:all]
+    action [:create, :grant]
+end


### PR DESCRIPTION
Change to only install MySQL if `node['phabricator']['mysql_host']`
points to localhost.
This allows the use of a remote MySQL Server (e.g. Amazon RDS) with
this cookbook.
