### PR TITLE
Include apt repository for arcanist

### DIFF
--- a/recipes/arcanist.rb
+++ b/recipes/arcanist.rb
@@ -9,6 +9,10 @@
 # This recipe installs the Arcanist libraries for use by developers.
 #
 
+# Including Apt will run `apt-get update` to ensure against trying to
+# pull expired versions of packages.
+include_recipe 'apt'
+
 package 'php5-cli'
 package 'php5-curl'
 package 'git'


### PR DESCRIPTION
I noticed when converging and testing cookbooks that arcanist was
failing to converge due to stale package versions for PHP.

Including apt cookbook will ensure that the apt database is fresh.
