### PR TITLE
Fix service startup and deployment

### DIFF
--- a/recipes/mysql_server.rb
+++ b/recipes/mysql_server.rb
@@ -41,7 +41,7 @@ mysql_config 'phabricator' do
     source 'phabricator.cnf.erb'
     instance 'default'
     action :create
-    notifies :restart, 'mysql_service[default]'
+    notifies :restart, 'mysql_service[default]', :immediately
 end
 
 mysql_database_user node['phabricator']['mysql_user'] do

--- a/templates/default/upstart/phd.erb
+++ b/templates/default/upstart/phd.erb
@@ -5,8 +5,13 @@
 description     "Phabricator daemon"
 author          "chef-client"
 
+<% if ['localhost', '127.0.0.1', '::1'].include?(node['phabricator']['mysql_host']) %>
 start on started mysql-default
 stop on stopping mysql-default
+<% else %>
+start on runlevel [2345]
+stop on runlevel [016]
+<% end %>
 
 setuid <%= node['phabricator']['user'] %>
 setgid <%= node['phabricator']['group'] %>


### PR DESCRIPTION
Firstly with mysql-server, it was being restarted with phab config
delayed, which during initial run (or during kitchen test run), meant
that phd service was being created before mysql had been restarted.
Thus when mysql was restarted it was restarting phd, causing the
behaviour noticed previously in a comment.

Secondly, with the `run_storage_upgrade` task, switched to using a guard
`not_if` rather than the preivous mechanism, as this should be more robust
and is cleaner.

Lastly with the phd upstart script, configured it to not depend on mysql starting
when mysql server is not local.
