### PR TITLE
install dir mode 755 to avoid breaking repo hosting

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -65,7 +65,7 @@ directory node['phabricator']['path'] do
     action :create
     user node['phabricator']['user']
     group node['phabricator']['group']
-    mode "0750"
+    mode "0755"
 end
 
 %w{ phabricator libphutil arcanist }.each do |repo|


### PR DESCRIPTION
Consistent with the change here: https://github.com/metno/cookbook-phabricator/pull/4/files#diff-55bf87238c9b8af164c5133a60721f12R68 in #4 

It would be good to _not_ use mode 750 since in many cases the vcs-user will not be in the group on the directory. This means that following a chef run after manualy setting up repo hosting, diffusion-hosted git clones starts failing with `bash: /opt/phabricator/phabricator/bin/ssh-exec: Permission denied`

This is pretty confusing since checking the permissions of the files themselves:
`/opt/phabricator/phabricator/bin/ssh-exec` and `/opt/phabricator/phabricator/scripts/ssh/ssh-exec.php` permissions seem fine (755); but it turns out that the lack of list permissions on /opt/phabricator screws you from the first

if you don't want to do 755, you should at least change it to 751
